### PR TITLE
inline-Condition für disabled-Attribut entfernt

### DIFF
--- a/src/main/resources/META-INF/resources/isyfact/formSelectOneRadio.xhtml
+++ b/src/main/resources/META-INF/resources/isyfact/formSelectOneRadio.xhtml
@@ -62,7 +62,7 @@
             <div class="#{cc.attrs.inputStyleClass}">
 
                 <t:selectOneRadio id="#{jsfHelper.escapeIdentifier(cc.attrs.reference)}" layout="spread" value="#{cc.attrs.value}"
-                        disabled="#{(not cc.attrs.inline and cc.attrs.disabled) or (cc.attrs.inline and cc.attrs.showPrintView)}">
+                        disabled="#{(cc.attrs.disabled) or (cc.attrs.showPrintView)}">
                     <f:selectItems value="#{cc.attrs.selectItems}" />
                 </t:selectOneRadio>
 


### PR DESCRIPTION
Problem war, dass im inline-Modus die Radiobutton-Group nicht disabled werden konnte.