### PR TITLE
[Sprint-114] IFS-4006 Release isy web 6.2.0 for IF 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v6.2.0
+- `IFS-4006`: IsyFact Versionsanhebung auf 3.2.0
+
 ## v6.1.0
 - `IFS-3938`: IsyFact Versionsanhebung auf 3.1.0
 

--- a/isy-web-doc/src/docs/antora/antora.yml
+++ b/isy-web-doc/src/docs/antora/antora.yml
@@ -1,7 +1,7 @@
 name: isyfact-jsf-doku
 title: JavaServer Faces (JSF)
-version: '6.1.x'
-display_version: '6.1'
+version: '6.2.x'
+display_version: '6.2'
 start_page: isy-web:konzept/konzept.adoc
 nav:
   - modules/isy-web/nav.adoc

--- a/isy-web-doc/src/docs/antora/modules/isy-web/pages/konzept/konzept.adoc
+++ b/isy-web-doc/src/docs/antora/modules/isy-web/pages/konzept/konzept.adoc
@@ -7,7 +7,7 @@ include::glossary:licence:partial$licence.adoc[]
 [cols="5,2,3",options="header"]
 |====
 |Name |Art |Version
-m|isy-web |Bibliothek |v6.1.0
+m|isy-web |Bibliothek |v6.2.0
 |====
 :linkaktuell: xref:isy-angular-widgets-doc:ROOT:konzept/konzept.adoc[Baustein isy-web-angular - Konzept]
 include::glossary:miscellaneous:partial$deprecated-baustein.adoc[]

--- a/isy-web-doc/src/docs/antora/modules/isy-web/pages/nutzungsvorgaben/nutzungsvorgaben.adoc
+++ b/isy-web-doc/src/docs/antora/modules/isy-web/pages/nutzungsvorgaben/nutzungsvorgaben.adoc
@@ -7,7 +7,7 @@ include::glossary:licence:partial$licence.adoc[]
 [cols="5m,2,3",options="header"]
 |====
 |Name |Art |Version
-|isy-web |Bibliothek |v6.1.0
+|isy-web |Bibliothek |v6.2.0
 |====
 :linkaktuell: https://isyfact.github.io/isy-angular-widgets/documentation/[Baustein isy-web-angular - Nutzungsvorgaben]
 include::glossary:miscellaneous:partial$deprecated-baustein.adoc[]

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </parent>
 
     <artifactId>isy-web-parent</artifactId>
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <isyfact-boms.version>3.1.0</isyfact-boms.version>
+        <isyfact-boms.version>3.2.0</isyfact-boms.version>
         <revision>0.0.0-SNAPSHOT</revision>
         <geronimo-el_2.2_spec.version>1.0.1</geronimo-el_2.2_spec.version>
         <geronimo-servlet_2.5_spec.version>1.2</geronimo-servlet_2.5_spec.version>


### PR DESCRIPTION
* build: IFS-4006 set version 3.2.0 for isyfact-standards and isyfact-boms
* docs: IFS-4006 set isy-web version 6.2 in antora.yml
* docs: IFS-4006 set isy-web version 6.2.0
* chore: IFS-4006 update changelog